### PR TITLE
Implement simple secure tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,92 @@
-"# local-remote-tunnel" 
+# Local Remote Tunnel
+
+This project provides a simple secure tunneling solution. It allows a client running on a local machine to forward TCP connections to a target host through a remote bridge. All traffic between the client and the server is encrypted using TLS.
+
+## Components
+
+- `lrt/` – Python package implementing the tunnel logic.
+- `tunnel.py` – small wrapper calling into the package.
+- `server.py` and `client.py` are kept for backward compatibility and simply invoke the same CLI.
+
+## Topology
+
+The tunnel uses a star topology. Each client installs the tunneling software
+and connects to a central server running on the host machine. The server acts as
+a bridge, relaying traffic between remote users and the services exposed by
+clients. Connections travel from the remote user to the server and then through
+the client's outbound tunnel to the local service.
+
+## Usage
+
+1. Generate a self‑signed certificate for the server. You can use the shell
+   script or the Python equivalent depending on your platform:
+   ```bash
+   ./generate_cert.sh
+   # or generate with pure Python (requires `cryptography`)
+   pip install cryptography rich pytest
+   python3 generate_cert.py
+   ```
+2. Start the server on the bridge host (you can listen on multiple ports):
+   ```bash
+   python3 tunnel.py server --cert cert.pem --key key.pem \
+       --listen 0.0.0.0:8000 --listen 0.0.0.0:9000 \
+      --allow-port 80 --allow-port 22 --token SECRET
+   # --allow-port restricts which destination ports clients may access (TCP or UDP)
+   # add -v for verbose logging
+   ```
+3. Start the client on the machine hosting the service you want to expose. Each
+   `--map` value forwards a local **TCP** address to a remote target via the server.
+   Use `--udp-map` for UDP services:
+   ```bash
+   python3 tunnel.py client --server bridge.example.com:8000 \
+       --map 127.0.0.1:8080=localhost:80 \
+       --map 127.0.0.1:2222=localhost:22 --token SECRET \
+       --retries 5
+       --udp-map 127.0.0.1:5353=localhost:5353
+   # --retries controls how many times the client will try to reconnect if the
+   # server is temporarily unreachable
+   # add -v for verbose logging
+   ```
+4. Remote users can reach the forwarded services by connecting to the server's
+   listening ports. Each connection must send the shared token first, followed by
+   the target host and port (handled automatically by the client) to prevent
+   abuse.
+
+5. To run the server continuously, create a systemd unit pointing at the `server` subcommand. A basic example is provided in `tunnel.service`.
+
+## Guided setup
+
+If you prefer an interactive setup, run `wizard.py` and follow the prompts. It
+will help you generate a certificate, start a server or launch a client with the
+appropriate parameters.
+
+This is a work in progress.
+
+## Testing
+
+The project ships with a battery of regression tests located in the `tests/`
+directory and executed with `pytest`.
+Run them with:
+
+```bash
+pytest -s
+# or on Windows
+./testall.ps1
+```
+
+To quickly check all scripts compile without running them, you can call:
+
+```powershell
+./compile.ps1
+```
+
+## Windows GUI
+
+For convenience Windows users can launch `windows_gui.py` which provides a
+minimal interface for starting the client and viewing its log output. Run:
+
+```bash
+python windows_gui.py
+```
+
+Fill in the server address, shared token and one or more mapping lines (in the form `LOCAL=HOST:PORT`) then click **Start**.

--- a/client.py
+++ b/client.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Thin wrapper executing the Local Remote Tunnel CLI."""
+
+from lrt.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/compile.ps1
+++ b/compile.ps1
@@ -1,0 +1,2 @@
+$files = Get-ChildItem -Recurse -Filter *.py | ForEach-Object { $_.FullName }
+python -m py_compile $files

--- a/generate_cert.py
+++ b/generate_cert.py
@@ -1,0 +1,36 @@
+import datetime
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+subject = issuer = x509.Name([
+    x509.NameAttribute(NameOID.COMMON_NAME, u"local-remote-tunnel")
+])
+now = datetime.datetime.now(datetime.timezone.utc)
+cert = (
+    x509.CertificateBuilder()
+    .subject_name(subject)
+    .issuer_name(issuer)
+    .public_key(key.public_key())
+    .serial_number(x509.random_serial_number())
+    .not_valid_before(now)
+    .not_valid_after(now + datetime.timedelta(days=365))
+    .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+    .sign(key, hashes.SHA256())
+)
+
+with open("key.pem", "wb") as f:
+    f.write(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+
+with open("cert.pem", "wb") as f:
+    f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+print("Generated cert.pem and key.pem")

--- a/generate_cert.sh
+++ b/generate_cert.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 \
+  -subj '/CN=local-remote-tunnel'
+echo "Generated cert.pem and key.pem"

--- a/lrt/__init__.py
+++ b/lrt/__init__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+__all__ = ["main"]

--- a/lrt/cli.py
+++ b/lrt/cli.py
@@ -1,0 +1,76 @@
+import argparse
+import logging
+from rich.logging import RichHandler
+
+from .client import run_client
+from .server import run_server
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Local Remote Tunnel")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    serv = sub.add_parser("server", help="Run tunnel server")
+    serv.add_argument("--cert", required=True, help="Path to TLS certificate")
+    serv.add_argument("--key", required=True, help="Path to TLS key")
+    serv.add_argument(
+        "--listen",
+        action="append",
+        metavar="ADDR",
+        help="Address to listen on (can be given multiple times)",
+    )
+    serv.add_argument("--token", required=True, help="Shared secret token")
+    serv.add_argument("--rate", type=int, default=60, help="Max connections per minute per IP")
+    serv.add_argument(
+        "--allow-port",
+        action="append",
+        metavar="PORT",
+        help="Restrict forwarding to these destination ports (can be repeated)",
+    )
+    serv.set_defaults(func=run_server)
+
+    cli = sub.add_parser("client", help="Run tunnel client")
+    cli.add_argument("--server", required=True, help="Server address")
+    cli.add_argument(
+        "--map",
+        action="append",
+        metavar="LOCAL=TARGET",
+        help="Forward TCP from LOCAL address to target host:port",
+    )
+    cli.add_argument(
+        "--udp-map",
+        action="append",
+        metavar="LOCAL=TARGET",
+        help="Forward UDP from LOCAL address to target host:port",
+    )
+    cli.add_argument("--token", required=True, help="Shared secret token")
+    cli.add_argument("--ca", help="CA certificate for server")
+    cli.add_argument(
+        "--retries",
+        type=int,
+        default=3,
+        help="Number of reconnect attempts if the server is unreachable",
+    )
+    cli.set_defaults(func=run_client)
+
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler()],
+    )
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/lrt/client.py
+++ b/lrt/client.py
@@ -1,0 +1,170 @@
+import asyncio
+import ssl
+import socket
+import logging
+
+logger = logging.getLogger(__name__)
+
+async def handle_local(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    server: str,
+    target: str,
+    token: str,
+    ca: str | None,
+    retries: int,
+):
+    attempt = 0
+    while True:
+        try:
+            server_host, server_port = server.split(":")
+            ssl_ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+            if ca:
+                ssl_ctx.load_verify_locations(ca)
+            else:
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
+            logger.debug("Connecting to %s (%s) attempt %d", server, target, attempt + 1)
+            remote_reader, remote_writer = await asyncio.open_connection(
+                server_host, int(server_port), ssl=ssl_ctx
+            )
+            connect_line = f"CONNECT {token} {target}\n".encode()
+            remote_writer.write(connect_line)
+            await remote_writer.drain()
+            logger.info("Connected to server %s for %s", server, target)
+            break
+        except Exception:
+            attempt += 1
+            if attempt > retries:
+                writer.close()
+                await writer.wait_closed()
+                return
+            await asyncio.sleep(min(2 ** attempt, 5))
+
+    async def pipe(reader1, writer1):
+        try:
+            while data := await reader1.read(4096):
+                writer1.write(data)
+                await writer1.drain()
+        finally:
+            writer1.close()
+
+    await asyncio.gather(
+        pipe(reader, remote_writer),
+        pipe(remote_reader, writer),
+    )
+
+
+async def handle_udp(
+    local_host: str,
+    local_port: int,
+    server: str,
+    target: str,
+    token: str,
+    ca: str | None,
+    retries: int,
+):
+    loop = asyncio.get_running_loop()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((local_host, local_port))
+    sock.setblocking(False)
+
+    attempt = 0
+    while True:
+        try:
+            server_host, server_port = server.split(":")
+            ssl_ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+            if ca:
+                ssl_ctx.load_verify_locations(ca)
+            else:
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
+            logger.debug(
+                "Connecting UDP to %s (%s) attempt %d", server, target, attempt + 1
+            )
+            reader, writer = await asyncio.open_connection(
+                server_host, int(server_port), ssl=ssl_ctx
+            )
+            writer.write(f"UDP {token} {target}\n".encode())
+            await writer.drain()
+            logger.info("UDP connected to server %s for %s", server, target)
+            break
+        except Exception:
+            attempt += 1
+            if attempt > retries:
+                sock.close()
+                return
+            await asyncio.sleep(min(2 ** attempt, 5))
+
+    peer = None
+
+    async def to_server():
+        nonlocal peer
+        while True:
+            data, addr = await loop.sock_recvfrom(sock, 65535)
+            peer = addr
+            writer.write(len(data).to_bytes(2, "big") + data)
+            await writer.drain()
+
+    async def from_server():
+        while True:
+            len_data = await reader.readexactly(2)
+            length = int.from_bytes(len_data, "big")
+            data = await reader.readexactly(length)
+            if peer:
+                await loop.sock_sendto(sock, data, peer)
+
+    await asyncio.gather(to_server(), from_server())
+
+
+def run_client(args) -> None:
+    if not args.map and not args.udp_map:
+        raise SystemExit("At least one --map or --udp-map must be provided")
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    servers = []
+    for m in args.map or []:
+        local, target = m.split("=", 1)
+        host, port = local.split(":")
+        srv_coro = asyncio.start_server(
+            lambda r, w, targ=target: handle_local(
+                r,
+                w,
+                args.server,
+                targ,
+                args.token,
+                args.ca,
+                args.retries,
+            ),
+            host,
+            int(port),
+        )
+        srv = loop.run_until_complete(srv_coro)
+        servers.append(srv)
+        addr = ", ".join(str(sock.getsockname()) for sock in srv.sockets)
+        logger.info("Forwarding %s -> %s", addr, target)
+
+    for m in args.udp_map or []:
+        local, target = m.split("=", 1)
+        host, port = local.split(":")
+        loop.create_task(
+            handle_udp(
+                host,
+                int(port),
+                args.server,
+                target,
+                args.token,
+                args.ca,
+                args.retries,
+            )
+        )
+        logger.info("UDP forwarding %s -> %s", local, target)
+
+    try:
+        loop.run_forever()
+    finally:
+        for srv in servers:
+            srv.close()
+            loop.run_until_complete(srv.wait_closed())

--- a/lrt/server.py
+++ b/lrt/server.py
@@ -1,0 +1,138 @@
+import asyncio
+import ssl
+import socket
+import logging
+import time
+from collections import defaultdict, deque
+
+logger = logging.getLogger(__name__)
+
+class RateLimiter:
+    """Simple per-IP rate limiter to avoid abuse."""
+
+    def __init__(self, limit_per_minute: int = 60):
+        self.limit = limit_per_minute
+        self.connections: defaultdict[str, deque] = defaultdict(deque)
+
+    def allowed(self, ip: str) -> bool:
+        now = time.time()
+        q = self.connections[ip]
+        while q and now - q[0] > 60:
+            q.popleft()
+        if len(q) >= self.limit:
+            return False
+        q.append(now)
+        return True
+
+async def handle_client(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    token: str,
+    limiter: RateLimiter,
+    allowed_ports: set[int] | None,
+):
+    peer = writer.get_extra_info("peername")[0]
+    if not limiter.allowed(peer):
+        writer.close()
+        await writer.wait_closed()
+        return
+    try:
+        line = await reader.readline()
+        parts = line.decode().strip().split()
+        if len(parts) != 3 or parts[1] != token:
+            raise ValueError("invalid header")
+        proto = parts[0]
+        host, port_str = parts[2].split(":")
+        port = int(port_str)
+        if allowed_ports is not None and port not in allowed_ports:
+            raise ValueError("port not allowed")
+    except Exception:
+        writer.close()
+        await writer.wait_closed()
+        return
+
+    loop = asyncio.get_running_loop()
+
+    if proto == "CONNECT":
+        try:
+            remote_reader, remote_writer = await asyncio.open_connection(host, port)
+        except Exception:
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        async def pipe(reader1, writer1):
+            try:
+                while data := await reader1.read(4096):
+                    writer1.write(data)
+                    await writer1.drain()
+            finally:
+                writer1.close()
+
+        await asyncio.gather(
+            pipe(reader, remote_writer),
+            pipe(remote_reader, writer),
+        )
+
+    elif proto == "UDP":
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect((host, port))
+        sock.setblocking(False)
+
+        async def to_remote():
+            try:
+                while True:
+                    len_data = await reader.readexactly(2)
+                    length = int.from_bytes(len_data, "big")
+                    data = await reader.readexactly(length)
+                    await loop.sock_sendall(sock, data)
+            finally:
+                sock.close()
+
+        async def to_client():
+            try:
+                while True:
+                    data = await loop.sock_recv(sock, 65535)
+                    writer.write(len(data).to_bytes(2, "big") + data)
+                    await writer.drain()
+            finally:
+                writer.close()
+
+        await asyncio.gather(to_remote(), to_client())
+
+    else:
+        writer.close()
+        await writer.wait_closed()
+
+
+def run_server(args) -> None:
+    if not args.listen:
+        args.listen = ["0.0.0.0:8000"]
+
+    ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ssl_ctx.load_cert_chain(args.cert, args.key)
+    limiter = RateLimiter(args.rate)
+    allowed_ports = {int(p) for p in args.allow_port} if args.allow_port else None
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    servers = []
+
+    for listen in args.listen:
+        host, port = listen.split(":")
+
+        async def handler(reader, writer):
+            await handle_client(reader, writer, args.token, limiter, allowed_ports)
+
+        server_coro = asyncio.start_server(handler, host, int(port), ssl=ssl_ctx)
+        srv = loop.run_until_complete(server_coro)
+        servers.append(srv)
+        addr = ", ".join(str(sock.getsockname()) for sock in srv.sockets)
+        logger.info("Serving on %s", addr)
+
+    try:
+        loop.run_forever()
+    finally:
+        for srv in servers:
+            srv.close()
+            loop.run_until_complete(srv.wait_closed())

--- a/server.py
+++ b/server.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Thin wrapper executing the Local Remote Tunnel CLI."""
+
+from lrt.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/testall.ps1
+++ b/testall.ps1
@@ -1,0 +1,2 @@
+pip install --quiet pytest rich cryptography
+pytest -q

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,95 @@
+import socket
+import subprocess
+import threading
+import sys
+
+from utils import wait_port
+
+TOKEN = "TESTTOKEN"
+
+
+def start_kv_server(port):
+    db = {}
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen()
+
+    def handler(conn):
+        with conn:
+            buf = b""
+            while True:
+                data = conn.recv(1024)
+                if not data:
+                    break
+                buf += data
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    parts = line.decode().strip().split(None, 2)
+                    if not parts:
+                        continue
+                    cmd = parts[0].upper()
+                    if cmd == "SET" and len(parts) == 3:
+                        db[parts[1]] = parts[2]
+                        conn.sendall(b"OK\n")
+                    elif cmd == "GET" and len(parts) == 2:
+                        conn.sendall((db.get(parts[1], "") + "\n").encode())
+                    else:
+                        conn.sendall(b"ERR\n")
+
+    def accept_loop():
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(target=handler, args=(conn,), daemon=True).start()
+
+    threading.Thread(target=accept_loop, daemon=True).start()
+    return srv
+
+
+def test_db():
+    subprocess.check_call([sys.executable, "generate_cert.py"])
+
+    kv_srv = start_kv_server(9201)
+
+    server_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "server",
+        "--cert",
+        "cert.pem",
+        "--key",
+        "key.pem",
+        "--listen",
+        "127.0.0.1:8200",
+        "--token",
+        TOKEN,
+        "--allow-port",
+        "9201",
+    ])
+    wait_port("127.0.0.1", 8200)
+
+    client_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "client",
+        "--server",
+        "127.0.0.1:8200",
+        "--map",
+        "127.0.0.1:9200=127.0.0.1:9201",
+        "--token",
+        TOKEN,
+    ])
+    wait_port("127.0.0.1", 9200)
+
+    s = socket.create_connection(("127.0.0.1", 9200))
+    s.sendall(b"SET foo bar\n")
+    resp = s.recv(100)
+    assert resp == b"OK\n"
+    s.sendall(b"GET foo\n")
+    resp = s.recv(100)
+    assert resp == b"bar\n"
+    s.close()
+
+    client_proc.terminate()
+    server_proc.terminate()
+    kv_srv.close()

--- a/tests/test_disallowed_port.py
+++ b/tests/test_disallowed_port.py
@@ -1,0 +1,79 @@
+import socket
+import subprocess
+import threading
+import sys
+
+from utils import wait_port
+
+TOKEN = "TESTTOKEN"
+
+
+def start_echo_server(port):
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen()
+
+    def handle(conn):
+        with conn:
+            while True:
+                data = conn.recv(4096)
+                if not data:
+                    break
+                conn.sendall(data)
+
+    def server_thread():
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(target=handle, args=(conn,), daemon=True).start()
+
+    threading.Thread(target=server_thread, daemon=True).start()
+    return srv
+
+
+def test_disallowed_port():
+    echo = start_echo_server(9511)
+    subprocess.check_call([sys.executable, "generate_cert.py"])
+    server_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "server",
+        "--cert",
+        "cert.pem",
+        "--key",
+        "key.pem",
+        "--listen",
+        "127.0.0.1:9510",
+        "--allow-port",
+        "80",
+        "--token",
+        TOKEN,
+    ])
+    wait_port("127.0.0.1", 9510)
+
+    client_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "client",
+        "--server",
+        "127.0.0.1:9510",
+        "--map",
+        "127.0.0.1:9512=127.0.0.1:9511",
+        "--token",
+        TOKEN,
+    ])
+    wait_port("127.0.0.1", 9512)
+
+    s = socket.socket()
+    try:
+        s.connect(("127.0.0.1", 9512))
+        s.sendall(b"test")
+        data = s.recv(10)
+        assert not data
+    except Exception:
+        pass
+    finally:
+        s.close()
+        client_proc.terminate()
+        server_proc.terminate()
+        echo.close()

--- a/tests/test_invalid_token.py
+++ b/tests/test_invalid_token.py
@@ -1,0 +1,79 @@
+import socket
+import subprocess
+import threading
+import sys
+
+from utils import wait_port
+
+TOKEN = "TESTTOKEN"
+
+
+def start_echo_server(port):
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen()
+
+    def handle(conn):
+        with conn:
+            while True:
+                data = conn.recv(4096)
+                if not data:
+                    break
+                conn.sendall(data)
+
+    def server_thread():
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(target=handle, args=(conn,), daemon=True).start()
+
+    threading.Thread(target=server_thread, daemon=True).start()
+    return srv
+
+
+def test_invalid_token():
+    echo = start_echo_server(9501)
+    subprocess.check_call([sys.executable, "generate_cert.py"])
+    server_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "server",
+        "--cert",
+        "cert.pem",
+        "--key",
+        "key.pem",
+        "--listen",
+        "127.0.0.1:9500",
+        "--allow-port",
+        "9501",
+        "--token",
+        TOKEN,
+    ])
+    wait_port("127.0.0.1", 9500)
+
+    client_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "client",
+        "--server",
+        "127.0.0.1:9500",
+        "--map",
+        "127.0.0.1:9502=127.0.0.1:9501",
+        "--token",
+        "WRONG",
+    ])
+    wait_port("127.0.0.1", 9502)
+
+    s = socket.socket()
+    try:
+        s.connect(("127.0.0.1", 9502))
+        s.sendall(b"test")
+        data = s.recv(10)
+        assert not data
+    except Exception:
+        pass
+    finally:
+        s.close()
+        client_proc.terminate()
+        server_proc.terminate()
+        echo.close()

--- a/tests/test_large_transfer.py
+++ b/tests/test_large_transfer.py
@@ -1,0 +1,85 @@
+import os
+import socket
+import subprocess
+import threading
+import sys
+
+from utils import wait_port
+
+TOKEN = "TESTTOKEN"
+SIZE = 10 * 1024 * 1024  # 10MB
+
+
+def start_echo_server(port):
+    def handler(conn):
+        with conn:
+            while True:
+                data = conn.recv(4096)
+                if not data:
+                    break
+                conn.sendall(data)
+
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen()
+
+    def run():
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(target=handler, args=(conn,), daemon=True).start()
+
+    threading.Thread(target=run, daemon=True).start()
+    return srv
+
+
+def test_large_transfer():
+    subprocess.check_call([sys.executable, "generate_cert.py"])
+
+    echo_srv = start_echo_server(9301)
+
+    server_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "server",
+        "--cert",
+        "cert.pem",
+        "--key",
+        "key.pem",
+        "--listen",
+        "127.0.0.1:8300",
+        "--token",
+        TOKEN,
+        "--allow-port",
+        "9301",
+    ])
+    wait_port("127.0.0.1", 8300)
+
+    client_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "client",
+        "--server",
+        "127.0.0.1:8300",
+        "--map",
+        "127.0.0.1:9300=127.0.0.1:9301",
+        "--token",
+        TOKEN,
+    ])
+    wait_port("127.0.0.1", 9300)
+
+    data = os.urandom(SIZE)
+    s = socket.create_connection(("127.0.0.1", 9300))
+    s.sendall(data)
+    received = bytearray()
+    while len(received) < len(data):
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        received.extend(chunk)
+    s.close()
+    assert received == data
+
+    client_proc.terminate()
+    server_proc.terminate()
+    echo_srv.close()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,83 @@
+import socket
+import subprocess
+import threading
+import sys
+import time
+
+from utils import wait_port
+
+TOKEN = "TESTTOKEN"
+DATA = b"hi"
+
+
+def start_echo_server(port):
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen()
+
+    def handle(conn):
+        with conn:
+            while True:
+                data = conn.recv(4096)
+                if not data:
+                    break
+                conn.sendall(data)
+
+    def loop():
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(target=handle, args=(conn,), daemon=True).start()
+
+    threading.Thread(target=loop, daemon=True).start()
+    return srv
+
+
+def test_retry():
+    subprocess.check_call([sys.executable, "generate_cert.py"])
+
+    echo_srv = start_echo_server(9401)
+
+    client_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "client",
+        "--server",
+        "127.0.0.1:8400",
+        "--map",
+        "127.0.0.1:9400=127.0.0.1:9401",
+        "--token",
+        TOKEN,
+        "--retries",
+        "5",
+    ])
+
+    time.sleep(2)
+
+    server_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "server",
+        "--cert",
+        "cert.pem",
+        "--key",
+        "key.pem",
+        "--listen",
+        "127.0.0.1:8400",
+        "--token",
+        TOKEN,
+        "--allow-port",
+        "9401",
+    ])
+
+    wait_port("127.0.0.1", 8400)
+
+    s = socket.create_connection(("127.0.0.1", 9400))
+    s.sendall(DATA)
+    resp = s.recv(len(DATA))
+    assert resp == DATA
+    s.close()
+
+    client_proc.terminate()
+    server_proc.terminate()
+    echo_srv.close()

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -1,0 +1,85 @@
+import os
+import socket
+import subprocess
+import threading
+import sys
+
+from utils import wait_port
+
+DATA_SIZE = 5 * 1024 * 1024  # 5MB
+TOKEN = "TESTTOKEN"
+
+
+def start_echo_server(port):
+    def handler(conn):
+        with conn:
+            while True:
+                data = conn.recv(4096)
+                if not data:
+                    break
+                conn.sendall(data)
+
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen()
+
+    def run():
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(target=handler, args=(conn,), daemon=True).start()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    return srv
+
+
+def test_tunnel():
+    subprocess.check_call([sys.executable, "generate_cert.py"])
+
+    echo_srv = start_echo_server(9001)
+
+    server_proc = subprocess.Popen(
+        [
+            "python3",
+            "tunnel.py",
+            "server",
+            "--cert",
+            "cert.pem",
+            "--key",
+            "key.pem",
+            "--listen",
+            "127.0.0.1:8000",
+            "--token",
+            TOKEN,
+            "--allow-port",
+            "9001",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    wait_port("127.0.0.1", 8000)
+
+    client_proc = subprocess.Popen(
+        ["python3", "tunnel.py", "client", "--server", "127.0.0.1:8000", "--map", "127.0.0.1:9000=127.0.0.1:9001", "--token", TOKEN],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    wait_port("127.0.0.1", 9000)
+
+    data = os.urandom(DATA_SIZE)
+    s = socket.create_connection(("127.0.0.1", 9000))
+    s.sendall(data)
+    received = bytearray()
+    while len(received) < len(data):
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        received.extend(chunk)
+    s.close()
+
+    assert received == data, "mismatched data"
+
+    client_proc.terminate()
+    server_proc.terminate()
+    echo_srv.close()

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -1,0 +1,70 @@
+import socket
+import subprocess
+import threading
+import sys
+import time
+
+from utils import wait_port
+
+TOKEN = "TESTTOKEN"
+DATA = b"ping"
+
+
+def start_udp_echo(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", port))
+
+    def loop():
+        while True:
+            data, addr = sock.recvfrom(65535)
+            sock.sendto(data, addr)
+
+    threading.Thread(target=loop, daemon=True).start()
+    return sock
+
+
+def test_udp_forward():
+    subprocess.check_call([sys.executable, "generate_cert.py"])
+
+    echo_sock = start_udp_echo(9801)
+
+    server_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "server",
+        "--cert",
+        "cert.pem",
+        "--key",
+        "key.pem",
+        "--listen",
+        "127.0.0.1:8600",
+        "--token",
+        TOKEN,
+        "--allow-port",
+        "9801",
+    ])
+    wait_port("127.0.0.1", 8600)
+
+    client_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "client",
+        "--server",
+        "127.0.0.1:8600",
+        "--udp-map",
+        "127.0.0.1:9800=127.0.0.1:9801",
+        "--token",
+        TOKEN,
+    ])
+    time.sleep(1)
+
+    cli = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    cli.sendto(DATA, ("127.0.0.1", 9800))
+    cli.settimeout(2)
+    resp, _ = cli.recvfrom(1024)
+    assert resp == DATA
+    cli.close()
+
+    client_proc.terminate()
+    server_proc.terminate()
+    echo_sock.close()

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -1,0 +1,64 @@
+import http.server
+import socket
+import subprocess
+import threading
+import urllib.request
+import sys
+
+from utils import wait_port
+
+TOKEN = "TESTTOKEN"
+
+
+def start_http_server(port):
+    handler = http.server.SimpleHTTPRequestHandler
+    server = http.server.HTTPServer(("127.0.0.1", port), handler)
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_webserver():
+    subprocess.check_call([sys.executable, "generate_cert.py"])
+
+    http_srv = start_http_server(9101)
+
+    server_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "server",
+        "--cert",
+        "cert.pem",
+        "--key",
+        "key.pem",
+        "--listen",
+        "127.0.0.1:8100",
+        "--token",
+        TOKEN,
+        "--allow-port",
+        "9101",
+    ])
+    wait_port("127.0.0.1", 8100)
+
+    client_proc = subprocess.Popen([
+        "python3",
+        "tunnel.py",
+        "client",
+        "--server",
+        "127.0.0.1:8100",
+        "--map",
+        "127.0.0.1:9100=127.0.0.1:9101",
+        "--token",
+        TOKEN,
+    ])
+    wait_port("127.0.0.1", 9100)
+
+    resp = urllib.request.urlopen("http://127.0.0.1:9100/")
+    assert resp.status == 200
+    data = resp.read(100)
+    assert data
+
+    client_proc.terminate()
+    server_proc.terminate()
+    http_srv.shutdown()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+import socket
+import time
+
+def wait_port(host: str, port: int, timeout: float = 5.0) -> None:
+    """Block until a TCP port starts accepting connections."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket() as sock:
+            if sock.connect_ex((host, port)) == 0:
+                return
+        time.sleep(0.1)
+    raise RuntimeError(f"Port {host}:{port} not ready after {timeout}s")

--- a/tunnel.py
+++ b/tunnel.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Entry point for the Local Remote Tunnel CLI."""
+
+from lrt import main
+
+if __name__ == "__main__":
+    main()

--- a/tunnel.service
+++ b/tunnel.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Local Remote Tunnel Server
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/python3 /path/to/tunnel.py server \
+    --cert /etc/tunnel/cert.pem \
+    --key /etc/tunnel/key.pem \
+    --listen 0.0.0.0:8000 \
+    --allow-port 80 \
+    --token SECRET
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/windows_gui.py
+++ b/windows_gui.py
@@ -1,0 +1,98 @@
+import sys
+import subprocess
+import threading
+import tkinter as tk
+from tkinter import ttk, scrolledtext, messagebox
+
+
+class TunnelGUI:
+    def __init__(self, root):
+        self.root = root
+        self.proc = None
+        root.title("Local Remote Tunnel Client")
+
+        frm = ttk.Frame(root, padding=10)
+        frm.grid(row=0, column=0, sticky="nsew")
+        root.columnconfigure(0, weight=1)
+        root.rowconfigure(0, weight=1)
+
+        ttk.Label(frm, text="Server:").grid(row=0, column=0, sticky="e")
+        self.server_var = tk.StringVar(value="localhost:8000")
+        ttk.Entry(frm, textvariable=self.server_var, width=40).grid(row=0, column=1, sticky="we")
+
+        ttk.Label(frm, text="Token:").grid(row=1, column=0, sticky="e")
+        self.token_var = tk.StringVar()
+        ttk.Entry(frm, textvariable=self.token_var, width=40, show="*").grid(row=1, column=1, sticky="we")
+
+        ttk.Label(frm, text="Mappings (one per line LOCAL=TARGET):").grid(row=2, column=0, sticky="ne")
+        self.map_text = tk.Text(frm, height=4, width=40)
+        self.map_text.grid(row=2, column=1, sticky="we")
+
+        ttk.Label(frm, text="CA cert (optional):").grid(row=3, column=0, sticky="e")
+        self.ca_var = tk.StringVar()
+        ttk.Entry(frm, textvariable=self.ca_var, width=40).grid(row=3, column=1, sticky="we")
+
+        ttk.Label(frm, text="Retries:").grid(row=4, column=0, sticky="e")
+        self.retries_var = tk.IntVar(value=3)
+        ttk.Entry(frm, textvariable=self.retries_var, width=5).grid(row=4, column=1, sticky="w")
+
+        btn_frame = ttk.Frame(frm)
+        btn_frame.grid(row=5, column=0, columnspan=2, pady=5)
+        self.start_btn = ttk.Button(btn_frame, text="Start", command=self.start)
+        self.start_btn.grid(row=0, column=0, padx=5)
+        self.stop_btn = ttk.Button(btn_frame, text="Stop", command=self.stop, state="disabled")
+        self.stop_btn.grid(row=0, column=1, padx=5)
+
+        self.log = scrolledtext.ScrolledText(frm, state="disabled", width=60, height=15)
+        self.log.grid(row=6, column=0, columnspan=2, sticky="nsew")
+        frm.rowconfigure(6, weight=1)
+
+    def append_log(self, text):
+        self.log.configure(state="normal")
+        self.log.insert(tk.END, text)
+        self.log.see(tk.END)
+        self.log.configure(state="disabled")
+
+    def reader_thread(self):
+        assert self.proc is not None
+        for line in self.proc.stdout:
+            self.append_log(line.decode())
+        self.append_log("\nClient stopped\n")
+        self.start_btn.config(state="normal")
+        self.stop_btn.config(state="disabled")
+        self.proc = None
+
+    def start(self):
+        if self.proc is not None:
+            return
+        server = self.server_var.get().strip()
+        token = self.token_var.get().strip()
+        maps = [m.strip() for m in self.map_text.get("1.0", tk.END).splitlines() if m.strip()]
+        if not server or not token or not maps:
+            messagebox.showerror("Error", "Server, token and at least one mapping are required")
+            return
+        cmd = [sys.executable, "tunnel.py", "client", "--server", server, "--token", token, "--retries", str(self.retries_var.get())]
+        for m in maps:
+            cmd.extend(["--map", m])
+        ca = self.ca_var.get().strip()
+        if ca:
+            cmd.extend(["--ca", ca])
+        self.append_log(f"Starting: {' '.join(cmd)}\n")
+        self.proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        threading.Thread(target=self.reader_thread, daemon=True).start()
+        self.start_btn.config(state="disabled")
+        self.stop_btn.config(state="normal")
+
+    def stop(self):
+        if self.proc:
+            self.proc.terminate()
+
+
+def main():
+    root = tk.Tk()
+    TunnelGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/wizard.py
+++ b/wizard.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Interactive wizard to set up and run the tunnel."""
+import os
+import subprocess
+
+
+def run_server():
+    port = input("Listen address [0.0.0.0:8000]: ").strip() or "0.0.0.0:8000"
+    token = input("Shared token: ").strip()
+    allow = input("Allowed destination ports (comma separated, blank for all): ")
+    allow_args = []
+    if allow:
+        for p in allow.split(','):
+            p = p.strip()
+            if p:
+                allow_args += ["--allow-port", p]
+    cert = input("TLS certificate path [cert.pem]: ").strip() or "cert.pem"
+    key = input("TLS key path [key.pem]: ").strip() or "key.pem"
+    if not os.path.exists(cert) or not os.path.exists(key):
+        print("Generating self-signed certificate...")
+        subprocess.check_call(["./generate_cert.sh"])
+    cmd = ["python3", "tunnel.py", "server", "--cert", cert, "--key", key,
+           "--listen", port, "--token", token] + allow_args
+    print("Running:", " ".join(cmd))
+    subprocess.call(cmd)
+
+
+def run_client():
+    server = input("Server address [host:port]: ").strip()
+    token = input("Shared token: ").strip()
+    mappings = []
+    while True:
+        m = input("Mapping LOCAL=HOST:PORT (blank to finish): ").strip()
+        if not m:
+            break
+        mappings += ["--map", m]
+    ca = input("CA certificate path (optional): ").strip()
+    retries = input("Reconnect attempts [3]: ").strip() or "3"
+    cmd = ["python3", "tunnel.py", "client", "--server", server, "--token", token,
+           "--retries", retries] + mappings
+    if ca:
+        cmd += ["--ca", ca]
+    print("Running:", " ".join(cmd))
+    subprocess.call(cmd)
+
+
+def main() -> None:
+    print("Local Remote Tunnel setup wizard")
+    mode = input("Select mode (server/client): ").strip().lower()
+    if mode.startswith('s'):
+        run_server()
+    elif mode.startswith('c'):
+        run_client()
+    else:
+        print("Unknown mode")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create Python client/server for TLS-encrypted tunneling
- add certificate generation helper script
- document how to use the tunnel in README
- improve test reliability with port checks

## Testing
- `python3 -m py_compile $(git ls-files '*.py' | tr '\n' ' ')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68403e9c5158832ba3388e846cf45a34